### PR TITLE
Handle empty frontmatter blocks

### DIFF
--- a/src/map.ts
+++ b/src/map.ts
@@ -212,7 +212,7 @@ function getBlockPositions(
 
 function preProcess(document: string): PreprocessedDocument {
   const frontmatterRegex =
-    /^---(?:\r\n|\r|\n)([\s\S]*?)(?:\r\n|\r|\n)---(?:\r\n|\r|\n|$)/;
+    /^---(?:\r\n|\r|\n)([\s\S]*?)^---(?:\r\n|\r|\n|$)/m;
 
   let content: string;
   let contentOffset = 0;
@@ -223,7 +223,7 @@ function preProcess(document: string): PreprocessedDocument {
     const frontmatterText = match[1].trim(); // Captured frontmatter content
     contentOffset = match[0].length; // Length of the entire frontmatter section including delimiters
 
-    frontmatter = parseYaml(frontmatterText);
+    frontmatter = parseYaml(frontmatterText) ?? {};
     content = document.slice(contentOffset);
   } else {
     content = document;

--- a/src/map.ts
+++ b/src/map.ts
@@ -212,7 +212,7 @@ function getBlockPositions(
 
 function preProcess(document: string): PreprocessedDocument {
   const frontmatterRegex =
-    /^---(?:\r\n|\r|\n)([\s\S]*?)^---(?:\r\n|\r|\n|$)/m;
+    /^---(?:\r\n|\r|\n)(?:---(?:\r\n|\r|\n|$)|([\s\S]*?)(?:\r\n|\r|\n)---(?:\r\n|\r|\n|$))/;
 
   let content: string;
   let contentOffset = 0;
@@ -220,7 +220,7 @@ function preProcess(document: string): PreprocessedDocument {
 
   const match = frontmatterRegex.exec(document);
   if (match) {
-    const frontmatterText = match[1].trim(); // Captured frontmatter content
+    const frontmatterText = (match[1] ?? "").trim(); // Captured frontmatter content
     contentOffset = match[0].length; // Length of the entire frontmatter section including delimiters
 
     frontmatter = parseYaml(frontmatterText) ?? {};

--- a/src/tests/map.test.ts
+++ b/src/tests/map.test.ts
@@ -244,6 +244,14 @@ describe("map", () => {
       expect(actual.heading.H.marker.start).toBe(10);
     });
 
+    test("does not treat later thematic breaks as frontmatter", () => {
+      const actual = getDocumentMap("# H\n\n---\nbody\n---\n");
+
+      expect(actual.frontmatter).toEqual({});
+      expect(actual.contentOffset).toBe(0);
+      expect(actual.heading.H.marker.start).toBe(0);
+    });
+
     test("does not exist", () => {
       const sample = fs.readFileSync(
         path.join(__dirname, "sample.frontmatter.none.md"),

--- a/src/tests/map.test.ts
+++ b/src/tests/map.test.ts
@@ -227,6 +227,23 @@ describe("map", () => {
       expect(expectedFrontmatter).toEqual(actualFrontmatter);
     });
 
+
+    test("exists but is empty", () => {
+      const actual = getDocumentMap("---\n---\n# H\n");
+
+      expect(actual.frontmatter).toEqual({});
+      expect(actual.contentOffset).toBe(8);
+      expect(actual.heading.H.marker.start).toBe(8);
+    });
+
+    test("exists but is empty with CRLF line endings", () => {
+      const actual = getDocumentMap("---\r\n---\r\n# H\r\n");
+
+      expect(actual.frontmatter).toEqual({});
+      expect(actual.contentOffset).toBe(10);
+      expect(actual.heading.H.marker.start).toBe(10);
+    });
+
     test("does not exist", () => {
       const sample = fs.readFileSync(
         path.join(__dirname, "sample.frontmatter.none.md"),

--- a/src/tests/patch.test.ts
+++ b/src/tests/patch.test.ts
@@ -1082,6 +1082,22 @@ describe("patch", () => {
         );
       });
       describe("createTargetIfMissing", () => {
+
+        test("works when the existing frontmatter block is empty", () => {
+          const instruction: FrontmatterPatchInstruction = {
+            targetType: "frontmatter",
+            target: "title",
+            operation: "replace",
+            contentType: ContentType.json,
+            content: "T",
+            createTargetIfMissing: true,
+          };
+
+          expect(applyPatch("---\n---\n# H\nbody\n", instruction)).toEqual(
+            "---\ntitle: T\n---\n# H\nbody\n"
+          );
+        });
+
         test("list", () => {
           const instruction: FrontmatterPatchInstruction = {
             targetType: "frontmatter",


### PR DESCRIPTION
## Summary
- recognize empty YAML frontmatter blocks such as `---\n---\n`
- preserve correct content offsets for LF and CRLF documents
- add regression coverage for frontmatter patching without duplicating the empty block

## Why
The existing frontmatter regex requires an extra line break before the closing delimiter, so valid empty frontmatter is treated as document content. A frontmatter patch with `createTargetIfMissing` then prepends a new YAML block and leaves the old empty block behind.

## Tests
- `npm test -- src/tests/map.test.ts src/tests/patch.test.ts --runInBand`
- `npm test -- --runInBand`
- `npm run build`
