### PR TITLE
Add a marketing landing page at the GitHub Pages root

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,15 +43,19 @@ jobs:
         uses: actions/configure-pages@v5
       - name: Install dependencies
         run: npm install
-      - name: Run Build Script
-        # Outputs to the './_site' directory by default
+      - name: Build API docs
+        # typedoc outputs to './docs/' (see typedoc.json)
         run: npm run docs
+      - name: Assemble site
+        # Landing page at the root, typedoc API docs under /api/
+        run: |
+          mkdir -p _site/api
+          cp -R site/. _site/
+          cp -R docs/. _site/api/
       - name: Upload artifact
-        # Automatically uploads an artifact from the './_site' directory by default
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
-          path: "./docs/"
+          path: "./_site/"
 
   # Deployment job
   deploy:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The same edit from a shell, with the bundled `mdpatch` CLI:
 echo "Decided: we ship on Thursday." | mdpatch patch append heading "Weekly Sync::Notes" notes.md
 ```
 
-**API docs:** https://coddingtonbear.github.io/markdown-patch/
+**Website:** https://coddingtonbear.github.io/markdown-patch/ · **API docs:** https://coddingtonbear.github.io/markdown-patch/api/
 
 **Contents**
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "bugs": {
     "url": "https://github.com/coddingtonbear/markdown-patch/issues"
   },
-  "homepage": "https://github.com/coddingtonbear/markdown-patch#readme",
+  "homepage": "https://coddingtonbear.github.io/markdown-patch/",
   "keywords": [
     "markdown",
     "patch",

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,472 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>markdown-patch — structure-aware edits to Markdown documents</title>
+<meta name="description" content="Address a heading, block, or frontmatter field in a Markdown document — then read it back, or append, replace, and move content. No line numbers, no regex, no sed.">
+<meta property="og:title" content="markdown-patch">
+<meta property="og:description" content="Structure-aware edits to Markdown documents. A TypeScript library and CLI.">
+<link rel="canonical" href="https://coddingtonbear.github.io/markdown-patch/">
+<link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🩹</text></svg>">
+<style>
+  :root {
+    --bg: #fbfcfb;
+    --bg-raised: #ffffff;
+    --bg-inset: #f1f5f2;
+    --ink: #16211a;
+    --ink-soft: #4b5a50;
+    --ink-faint: #8a978e;
+    --line: #dde5df;
+    --accent: #1a7f4b;
+    --accent-ink: #0f5c35;
+    --add-bg: #e2f4e8;
+    --add-ink: #14602f;
+    --mono: ui-monospace, "SF Mono", "Cascadia Code", Menlo, Consolas, monospace;
+    --sans: system-ui, -apple-system, "Segoe UI", sans-serif;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #101512;
+      --bg-raised: #161d18;
+      --bg-inset: #0c100d;
+      --ink: #e6ede8;
+      --ink-soft: #a8b5ac;
+      --ink-faint: #6b776f;
+      --line: #26302a;
+      --accent: #3fbf7f;
+      --accent-ink: #5ed99a;
+      --add-bg: #143423;
+      --add-ink: #7fe0ab;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--ink);
+    font-family: var(--sans); line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
+  }
+  a { color: var(--accent-ink); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  a:focus-visible, button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  .wrap { max-width: 1080px; margin: 0 auto; padding: 0 24px; }
+
+  nav {
+    display: flex; align-items: center; gap: 20px;
+    padding: 18px 0; border-bottom: 1px solid var(--line);
+  }
+  .brand { font-family: var(--mono); font-weight: 700; font-size: 1rem; color: var(--ink); }
+  .brand .tick { color: var(--accent); }
+  nav .links { margin-left: auto; display: flex; gap: 20px; font-size: 0.92rem; flex-wrap: wrap; }
+  nav .links a { color: var(--ink-soft); }
+
+  .hero { display: grid; grid-template-columns: minmax(300px, 5fr) 7fr; gap: 48px; padding: 64px 0 56px; align-items: start; }
+  @media (max-width: 860px) { .hero { grid-template-columns: 1fr; } }
+  h1 {
+    font-size: clamp(1.9rem, 3.6vw, 2.7rem); line-height: 1.12;
+    letter-spacing: -0.02em; margin: 0 0 16px; text-wrap: balance; font-weight: 750;
+  }
+  .hero p.lede { font-size: 1.08rem; color: var(--ink-soft); margin: 0 0 24px; max-width: 42ch; }
+  .install {
+    display: flex; align-items: center; gap: 10px; font-family: var(--mono); font-size: 0.92rem;
+    background: var(--bg-inset); border: 1px solid var(--line); border-radius: 8px;
+    padding: 10px 14px; margin-bottom: 20px; width: fit-content;
+  }
+  .install .dollar { color: var(--ink-faint); user-select: none; }
+  .ctas { display: flex; gap: 12px; flex-wrap: wrap; }
+  .btn {
+    display: inline-block; padding: 10px 18px; border-radius: 8px; font-weight: 600;
+    font-size: 0.95rem; border: 1px solid transparent;
+  }
+  .btn.primary { background: var(--accent); color: #fff; }
+  .btn.primary:hover { text-decoration: none; filter: brightness(1.08); }
+  .btn.ghost { border-color: var(--line); color: var(--ink); background: var(--bg-raised); }
+  .ctas .hint { flex-basis: 100%; font-size: 0.82rem; color: var(--ink-faint); margin-top: 2px; }
+
+  .demo {
+    border: 1px solid var(--line); border-radius: 12px; background: var(--bg-raised);
+    overflow: hidden; box-shadow: 0 1px 3px rgb(0 0 0 / 0.05);
+  }
+  .demo-head {
+    display: flex; align-items: center; gap: 8px; padding: 10px 14px;
+    border-bottom: 1px solid var(--line); font-size: 0.8rem; color: var(--ink-faint);
+    text-transform: uppercase; letter-spacing: 0.08em;
+  }
+  .demo-head .live { color: var(--accent-ink); font-weight: 700; }
+  .ops { display: flex; flex-wrap: wrap; gap: 8px; padding: 12px 14px; border-bottom: 1px solid var(--line); }
+  .ops button {
+    font: 600 0.85rem var(--sans); color: var(--ink-soft); background: var(--bg-inset);
+    border: 1px solid var(--line); border-radius: 999px; padding: 6px 14px; cursor: pointer;
+  }
+  .ops button[aria-pressed="true"] { background: var(--accent); border-color: var(--accent); color: #fff; }
+  .panes { display: grid; grid-template-columns: 1fr 1fr; }
+  @media (max-width: 640px) { .panes { grid-template-columns: 1fr; } }
+  .pane { padding: 14px 16px; min-width: 0; }
+  .pane + .pane { border-left: 1px solid var(--line); }
+  @media (max-width: 640px) { .pane + .pane { border-left: 0; border-top: 1px solid var(--line); } }
+  .pane h3 {
+    margin: 0 0 10px; font-size: 0.72rem; text-transform: uppercase;
+    letter-spacing: 0.1em; color: var(--ink-faint); font-weight: 700;
+  }
+  pre {
+    margin: 0; font-family: var(--mono); font-size: 0.82rem; line-height: 1.5;
+    overflow-x: auto; tab-size: 2;
+  }
+  .docline { display: block; padding: 0 6px; border-radius: 3px; white-space: pre; }
+  .docline.add { background: var(--add-bg); color: var(--add-ink); }
+  .docline.add::before { content: "+ "; font-weight: 700; }
+  .instr { background: var(--bg-inset); border: 1px solid var(--line); border-radius: 8px; padding: 10px 12px; margin-bottom: 10px; }
+  .cli-line { color: var(--ink-soft); font-size: 0.78rem; }
+  .cli-line .dollar { color: var(--ink-faint); }
+  .key { color: var(--accent-ink); }
+
+  section { padding: 48px 0; border-top: 1px solid var(--line); }
+  section h2 { font-size: 1.5rem; letter-spacing: -0.01em; margin: 0 0 8px; text-wrap: balance; }
+  section > .wrap > p.sub { color: var(--ink-soft); margin: 0 0 28px; max-width: 62ch; }
+  .cards { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+  @media (max-width: 820px) { .cards { grid-template-columns: 1fr; } }
+  .card { border: 1px solid var(--line); border-radius: 10px; padding: 20px; background: var(--bg-raised); }
+  .card h3 { margin: 0 0 8px; font-size: 1.02rem; }
+  .card p { margin: 0; font-size: 0.92rem; color: var(--ink-soft); }
+  .card code { font-family: var(--mono); font-size: 0.85em; background: var(--bg-inset); padding: 1px 5px; border-radius: 4px; }
+
+  .cmd-scroll { overflow-x: auto; }
+  .cmds { border-collapse: collapse; font-size: 0.92rem; min-width: 100%; }
+  .cmds th, .cmds td { text-align: left; padding: 9px 20px 9px 0; vertical-align: baseline; }
+  .cmds th {
+    font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.1em;
+    color: var(--ink-faint); border-bottom: 1px solid var(--line); font-weight: 700;
+  }
+  .cmds td { border-bottom: 1px solid var(--line); color: var(--ink-soft); }
+  .cmds td:first-child { font-family: var(--mono); font-size: 0.85rem; color: var(--ink); white-space: nowrap; }
+  .cmds td code { font-family: var(--mono); font-size: 0.85em; background: var(--bg-inset); padding: 1px 5px; border-radius: 4px; }
+  .rw {
+    font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em;
+    border-radius: 999px; padding: 3px 10px; white-space: nowrap;
+  }
+  .rw.write { background: var(--add-bg); color: var(--add-ink); }
+  .rw.read { background: var(--bg-inset); color: var(--ink-soft); border: 1px solid var(--line); }
+
+  .tok-panel {
+    border: 1px solid var(--line); border-radius: 12px; background: var(--bg-raised);
+    padding: 22px 26px;
+  }
+  .tok-panel h3 { margin: 0 0 18px; font-size: 1.02rem; }
+  .bar-row { display: grid; grid-template-columns: 180px 1fr 80px; gap: 14px; align-items: center; margin: 12px 0; }
+  @media (max-width: 620px) { .bar-row { grid-template-columns: 1fr; gap: 4px; } }
+  .bar-label { font-size: 0.88rem; color: var(--ink-soft); }
+  .bar-track { background: var(--bg-inset); border-radius: 5px; height: 24px; overflow: hidden; }
+  .bar-fill { height: 100%; border-radius: 5px; background: var(--ink-faint); width: 0; transition: width 0.9s cubic-bezier(0.2, 0.7, 0.2, 1); }
+  .bar-fill.accent { background: var(--accent); }
+  .bar-num { font-family: var(--mono); font-size: 0.88rem; text-align: right; font-variant-numeric: tabular-nums; }
+  .bar-num strong { color: var(--accent-ink); }
+  .tok-note { font-size: 0.82rem; color: var(--ink-faint); margin: 16px 0 0; }
+  @media (prefers-reduced-motion: reduce) { .bar-fill { transition: none; } }
+
+  footer { border-top: 1px solid var(--line); padding: 28px 0 40px; color: var(--ink-faint); font-size: 0.85rem; }
+  footer .wrap { display: flex; gap: 20px; flex-wrap: wrap; }
+</style>
+</head>
+<body>
+
+<div class="wrap">
+  <nav>
+    <span class="brand">markdown<span class="tick">-</span>patch</span>
+    <div class="links">
+      <a href="#docs">Docs</a>
+      <a href="#cli">CLI</a>
+      <a href="#agents">For agents</a>
+      <a href="./api/">API reference</a>
+      <a href="https://github.com/coddingtonbear/markdown-patch">GitHub</a>
+    </div>
+  </nav>
+
+  <div class="hero">
+    <div>
+      <h1>Structure-aware edits to Markdown documents.</h1>
+      <p class="lede">Address a heading, block, or frontmatter field — then read it back, or append, replace, and move content. No line numbers, no regex, no <code style="font-family:var(--mono)">sed</code>.</p>
+      <div class="install"><span class="dollar">$</span> npm install markdown-patch</div>
+      <div class="ctas">
+        <a class="btn primary" href="https://github.com/coddingtonbear/markdown-patch#library-usage">Use the library</a>
+        <a class="btn ghost" href="https://github.com/coddingtonbear/markdown-patch#cli-reference">Use the CLI</a>
+        <span class="hint">One engine, two front doors — <code style="font-family:var(--mono)">mdpatch</code> ships in the box.</span>
+      </div>
+    </div>
+
+    <div class="demo" aria-label="Interactive patch demo">
+      <div class="demo-head"><span class="live">●&nbsp;Try it</span> pick an operation, watch it land</div>
+      <div class="ops" id="ops" role="group" aria-label="Example operations"></div>
+      <div class="panes">
+        <div class="pane">
+          <h3>The instruction</h3>
+          <div class="instr"><pre id="instr"></pre></div>
+          <p class="cli-line" id="cli"></p>
+        </div>
+        <div class="pane">
+          <h3 id="result-title">notes.md — after</h3>
+          <pre id="result"></pre>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<section id="docs">
+  <div class="wrap">
+    <h2>The failure modes you already know, closed off.</h2>
+    <p class="sub">The obvious ways to edit Markdown programmatically all break on contact with real documents. Each one is handled by the engine, not by your code.</p>
+    <div class="cards">
+      <div class="card">
+        <h3>Whitespace is library-owned</h3>
+        <p>The engine supplies every separator, so <code>"X"</code>, <code>"X\n"</code>, and <code>"\nX\n"</code> all produce the same document. One missing newline can never merge two paragraphs again.</p>
+      </div>
+      <div class="card">
+        <h3>Heading levels are relative</h3>
+        <p>A <code># Section</code> in your content lands as a direct child of wherever it's written — the engine rebases levels, so pasted subtrees always fit their new depth.</p>
+      </div>
+      <div class="card">
+        <h3>Stale writes fail cleanly</h3>
+        <p>Pass <code>ifMatch</code> with the document's version token. If the file changed under you, the patch throws instead of landing in the wrong place.</p>
+      </div>
+      <div class="card">
+        <h3>Duplicates are addressable</h3>
+        <p>Two identical <code>### Fixed</code> headings? The document map hands each occurrence a distinct address — a regex matches both, a path names exactly one.</p>
+      </div>
+      <div class="card">
+        <h3>Tables are structured</h3>
+        <p>Append rows as <code>string[][]</code> — cells are content, not source. Pipes are escaped for you and column counts are checked.</p>
+      </div>
+      <div class="card">
+        <h3>Reads mirror writes</h3>
+        <p><code>readTarget</code> takes the same address as <code>patch</code>. Read at a scope, replace at that scope with the value unchanged: a guaranteed no-op.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="cli">
+  <div class="wrap">
+    <h2>Write it — or just read it.</h2>
+    <p class="sub">Every address you can patch, you can also query. The bundled <code style="font-family:var(--mono)">mdpatch</code> CLI and the TypeScript API drive the same engine: two commands write, two retrieve.</p>
+    <div class="cmd-scroll"><table class="cmds">
+      <tr><th>command</th><th></th><th>what it does</th></tr>
+      <tr><td>mdpatch patch</td><td><span class="rw write">write</span></td><td>quick flag-based form for common single edits</td></tr>
+      <tr><td>mdpatch apply</td><td><span class="rw write">write</span></td><td>full instruction JSON — moves, table rows, <code>ifMatch</code> pipelines</td></tr>
+      <tr><td>mdpatch query</td><td><span class="rw read">read</span></td><td>print a target's content: a section, a block, a frontmatter value</td></tr>
+      <tr><td>mdpatch print-map</td><td><span class="rw read">read</span></td><td>show everything addressable — headings, blocks, fields, version token</td></tr>
+    </table></div>
+    <p class="sub" style="margin:18px 0 0">In the library, <code style="font-family:var(--mono)">readTarget</code> is the mirror image of <code style="font-family:var(--mono)">patch</code> — the same <code style="font-family:var(--mono)">(targetType, target)</code> address, read instead of written. Pull one section out of a note without parsing anything yourself.</p>
+  </div>
+</section>
+
+<section id="agents">
+  <div class="wrap">
+    <h2>Built for editors that aren't people.</h2>
+    <p class="sub">An LLM agent shouldn't re-emit a 4,000-token file to add one paragraph — and with markdown-patch it can't mangle the 3,900 tokens it had no business touching. This is the engine behind <a href="https://github.com/coddingtonbear/obsidian-local-rest-api">Obsidian Local REST API</a>'s PATCH endpoints and MCP tools, where exactly that kind of client is the norm.</p>
+
+    <div class="tok-panel">
+      <h3>Output tokens to add one paragraph to a 4,000-token note</h3>
+      <div class="bar-row">
+        <span class="bar-label">Re-emit the whole file</span>
+        <div class="bar-track"><div class="bar-fill" data-w="100%"></div></div>
+        <span class="bar-num">~4,000</span>
+      </div>
+      <div class="bar-row">
+        <span class="bar-label">Re-emit the section</span>
+        <div class="bar-track"><div class="bar-fill" data-w="24%"></div></div>
+        <span class="bar-num">~950</span>
+      </div>
+      <div class="bar-row">
+        <span class="bar-label">One patch instruction</span>
+        <div class="bar-track"><div class="bar-fill accent" data-w="2.5%"></div></div>
+        <span class="bar-num"><strong>~60</strong></span>
+      </div>
+      <p class="tok-note">Illustrative counts for a typical meeting note. Retrieval is cheap too: the agent reads the compact document map, not the whole file.</p>
+    </div>
+
+    <div class="cards" style="margin-top:24px">
+      <div class="card">
+        <h3>1 · Map</h3>
+        <p><code>print-map</code> hands the model a few dozen tokens describing everything addressable — including distinct addresses for duplicate headings — plus a <code>version</code> token.</p>
+      </div>
+      <div class="card">
+        <h3>2 · Target</h3>
+        <p>The model picks an address straight off the map and, if it needs context, <code>query</code>-reads just that section — no full-file round trips.</p>
+      </div>
+      <div class="card">
+        <h3>3 · Patch</h3>
+        <p>One small instruction lands the edit. Sent with <code>ifMatch</code>, a stale write throws instead of landing in the wrong place — and retrying from a fresh map is the agent's native gesture.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="wrap">
+    <span>MIT license</span>
+    <span><a href="https://github.com/coddingtonbear/markdown-patch">coddingtonbear/markdown-patch</a></span>
+    <span><a href="./api/">API reference</a></span>
+    <span><a href="https://github.com/coddingtonbear/markdown-patch#migrating-from-1x">Migrating from 1.x</a></span>
+  </div>
+</footer>
+
+<script>
+  const BASE = [
+    "---",
+    "status: draft",
+    "---",
+    "",
+    "# Weekly Sync",
+    "",
+    "## Notes",
+    "",
+    "Kim walked through the Q3 timeline.",
+    "",
+    "## Attendees",
+    "",
+    "- Adam",
+    "- Kim",
+  ];
+  // Each op: label, instruction (JSON) or instrText (library call), optional CLI
+  // line, and the resulting output as [lineText, isAdded] pairs (precomputed
+  // against the engine's documented semantics).
+  function lines(edit) {
+    return BASE.map((l) => [l, false]).flatMap(edit);
+  }
+  const OPS = [
+    {
+      label: "Append to a section",
+      instr: {
+        targetType: "heading",
+        target: ["Weekly Sync", "Notes"],
+        operation: "append",
+        content: "Decided: we ship on Thursday.",
+      },
+      cli: 'echo "Decided: we ship on Thursday." | mdpatch patch append heading "Weekly Sync::Notes" notes.md',
+      result: lines(([l, a]) =>
+        l === "Kim walked through the Q3 timeline."
+          ? [[l, a], ["", false], ["Decided: we ship on Thursday.", true]]
+          : [[l, a]]
+      ),
+    },
+    {
+      label: "Rename a heading",
+      instr: {
+        targetType: "heading",
+        target: ["Weekly Sync", "Attendees"],
+        operation: "replace",
+        scope: "marker",
+        content: "People",
+      },
+      cli: 'echo "People" | mdpatch patch replace heading "Weekly Sync::Attendees" notes.md -s marker',
+      result: lines(([l, a]) =>
+        l === "## Attendees" ? [["## People", true]] : [[l, a]]
+      ),
+    },
+    {
+      label: "Set frontmatter",
+      instr: {
+        targetType: "frontmatter",
+        target: "status",
+        operation: "replace",
+        value: "final",
+      },
+      cli: "echo '\"final\"' | mdpatch patch replace frontmatter status notes.md",
+      result: lines(([l, a]) =>
+        l === "status: draft" ? [["status: final", true]] : [[l, a]]
+      ),
+    },
+    {
+      label: "Extend the list",
+      instr: {
+        targetType: "heading",
+        target: ["Weekly Sync", "Attendees"],
+        within: -1,
+        operation: "append",
+        content: "\\n- Priya",
+      },
+      cli: null,
+      result: lines(([l, a]) =>
+        l === "- Kim" ? [[l, a], ["- Priya", true]] : [[l, a]]
+      ),
+    },
+    {
+      label: "Read a section",
+      instrText: 'readTarget(note, {\n  targetType: "heading",\n  target: ["Weekly Sync", "Notes"]\n})',
+      cli: 'mdpatch query heading "Weekly Sync::Notes" notes.md',
+      resultTitle: "stdout — nothing written",
+      result: [["Kim walked through the Q3 timeline.", false]],
+    },
+    {
+      label: "Map the document",
+      instrText: "projectMap(buildModel(note))",
+      cli: "mdpatch print-map notes.md",
+      resultTitle: "the addressable map",
+      result: [
+        ["{", false],
+        ['  "version": "2b0a04",', false],
+        ['  "frontmatterFields": [', false],
+        ['    "status"', false],
+        ["  ],", false],
+        ['  "headings": {', false],
+        ['    "Weekly Sync": {', false],
+        ['      "Notes": {},', false],
+        ['      "Attendees": {}', false],
+        ["    }", false],
+        ["  },", false],
+        ['  "blocks": []', false],
+        ["}", false],
+      ],
+    },
+  ];
+
+  const opsEl = document.getElementById("ops");
+  const instrEl = document.getElementById("instr");
+  const cliEl = document.getElementById("cli");
+  const resultEl = document.getElementById("result");
+  const resultTitleEl = document.getElementById("result-title");
+
+  function renderInstr(obj) {
+    const json = JSON.stringify(obj, null, 2);
+    return json.replace(/"(\w+)":/g, '<span class="key">"$1"</span>:');
+  }
+  function esc(s) {
+    return s.replace(/&/g, "&amp;").replace(/</g, "&lt;");
+  }
+  function select(i) {
+    const op = OPS[i];
+    [...opsEl.children].forEach((b, j) =>
+      b.setAttribute("aria-pressed", String(i === j))
+    );
+    instrEl.innerHTML = op.instr ? renderInstr(op.instr) : esc(op.instrText);
+    resultTitleEl.textContent = op.resultTitle || "notes.md — after";
+    cliEl.innerHTML = op.cli
+      ? '<span class="dollar">$</span> ' + esc(op.cli)
+      : "<em>Full-model instructions run through <code>mdpatch apply</code>.</em>";
+    resultEl.innerHTML = op.result
+      .map(([l, add]) =>
+        '<span class="docline' + (add ? " add" : "") + '">' + (esc(l) || " ") + "</span>"
+      )
+      .join("");
+  }
+  OPS.forEach((op, i) => {
+    const b = document.createElement("button");
+    b.textContent = op.label;
+    b.addEventListener("click", () => select(i));
+    opsEl.appendChild(b);
+  });
+  select(0);
+
+  const fills = document.querySelectorAll(".bar-fill");
+  const reduced = matchMedia("(prefers-reduced-motion: reduce)").matches;
+  function runBars() { fills.forEach((f) => (f.style.width = f.dataset.w)); }
+  if (reduced) { runBars(); }
+  else {
+    const obs = new IntersectionObserver((entries) => {
+      if (entries.some((e) => e.isIntersecting)) { runBars(); obs.disconnect(); }
+    }, { threshold: 0.4 });
+    obs.observe(document.querySelector(".tok-panel"));
+  }
+</script>
+</body>
+</html>


### PR DESCRIPTION
## What this does

Replaces the typedoc output at the root of https://coddingtonbear.github.io/markdown-patch/ with a marketing landing page, and moves the API docs under `/api/`. The design was chosen from three reviewed mockups (docs-as-landing archetype with an interactive demo hero, plus a CLI read/write section and a "built for agents" section).

- **`site/index.html`** — the whole site: one hand-written, dependency-free static file (no generator, no external requests, light/dark via `prefers-color-scheme`, `prefers-reduced-motion` respected).
- **`.github/workflows/docs.yml`** — the build now assembles `_site/` from `site/` (root) + typedoc output (`/api/`) and uploads that instead of `docs/` directly.
- **`README.md` / `package.json`** — the API-docs link now points at `/api/`; `homepage` points at the site.

## Evidence this adds no risk

- **The interactive demo cannot lie**: all six demo results (append, marker rename, frontmatter replace, `within` list append, `readTarget`, `projectMap`) are precomputed, and each one was verified **byte-for-byte against the real engine** built from this branch — including the real `version` token `2b0a04` for the demo document. Verification script output: 6/6 PASS.
- **In verifying, a README drift was caught, not copied**: README's "Inspecting a document" example shows `headings` as an array of paths, but the engine actually returns a nested object (`{"Weekly Sync": {"Notes": {}, ...}}`). The site shows the engine's real output; the README fix is tracked separately.
- **No engine code changed**: `src/` is untouched; the full suite passes (20 suites, 511 tests).
- **The workflow's assembly step was executed locally** (`cp -R site/. _site/ && cp -R docs/. _site/api/`) and produces the expected layout: `index.html` at root, typedoc tree under `api/`.

## Known trade-offs / honest gaps

- **Old API-doc URLs break**: everything previously at `/<page>` (typedoc's `classes/…`, `interfaces/…`) moves to `/api/<page>`. No redirects are added; anything deep-linking the old paths (including search-engine results) will 404 until re-crawled.
- The demo is **precomputed, not live** — results are engine-verified but static. Bundling the actual engine for the browser is a possible follow-up.
- The token-count bar chart is labeled *illustrative* on the page, and is.
- Page rendering was reviewed as a served artifact during mockup review, but not re-screenshotted post-conversion to a standalone file; the conversion changed only the document shell (doctype/head) and link targets.
- The Pages deploy itself only runs on merge to main — the workflow change is exercised for real the first time then. Its steps are plain `cp`, run locally above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VbjyyWq1fcRe3iBg69oxtX